### PR TITLE
Release 2.2 edits

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -14,21 +14,21 @@ jobs:
       matrix:
         include:
 
-          - name: Python 3.8
+          - name: Python 3.10
             os: ubuntu-latest
-            python: 3.8
+            python: 3.10
 
-          - name: Python 3.9
+          - name: Python 3.11
             os: ubuntu-latest
-            python: 3.9
+            python: 3.11
 
-          - name: Python 3.9 Mac
+          - name: Python 3.11 Mac
             os: macos-latest
-            python: 3.9
+            python: 3.11
 
           - name: Python Long
             os: ubuntu-latest
-            python: 3.9
+            python: 3.11
 
     steps:
     - name: Checkout code
@@ -72,7 +72,7 @@ jobs:
       with:
         activate-environment: stips
         environment-file: environment.yml
-        python-version: 3.9
+        python-version: 3.11
         auto-activate-base: false
 
     - name: Build Docs

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -16,7 +16,7 @@ jobs:
 
           - name: Python 3.10
             os: ubuntu-latest
-            python: 3.10
+            python: "3.10"
 
           - name: Python 3.11
             os: ubuntu-latest

--- a/docs/basic_tutorial.rst
+++ b/docs/basic_tutorial.rst
@@ -267,16 +267,15 @@ We use ``matplotlib`` to plot the resulting simulated image.
 .. code-block:: python
 
   import matplotlib
-  from matplotlib import style
+  import matplotlib.pyplot as plt
+  from astropy.io import fits
   matplotlib.rcParams['axes.grid'] = False
   matplotlib.rcParams['image.origin'] = 'lower'
-  import matplotlib.pyplot as plot
-  from astropy.io import fits
 
   with fits.open(fits_file) as result_file:
     result_data = result_file[1].data
 
-  fig1 = plot.figure()
-  im = plot.matshow(result_data)
+  fig1 = plt.figure()
+  im = plt.matshow(result_data)
 
 Alternatively, you can open the final ``.fits`` file in your preferred imaging software.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -65,17 +65,18 @@ scene with the Roman WFI F129 filter offset by 0.5 degrees in RA and rotated by 
 
     fits_file, mosaic_file, params = obm.finalize(mosaic=False)
 
-In this case, the output catalog(s) will show the actual applied count rates. Whether there 
-is only one output catalog or two depends on the input catalog format.
+In this case, the output catalog(s) will show the actual applied count rates.
+Whether there is only one output catalog or two depends on the input catalog format.
 
 
 Fast Extended Sources
 ----------------------
 
-In STIPS 2.2 we included an option to inject extended sources in scenes using a sersic-profile
-approximation, which is less accurate than the current implementation, but ~8 times faster.
+As of version 2.2, STIPS includes an option to inject extended sources in scenes
+using a Sersic-profile approximation. This approximation is ~8 times faster than
+the current implementation, but it is also less accurate.
 
-To activate this feature, users must turn on the ``fast_galaxy`` flag. This is how the syntax 
+To activate this feature, users must turn on the ``fast_galaxy`` flag. This is how the syntax
 looks, starting from the examples listed in the :doc:`STIPS Basic Tutorial <basic_tutorial>`.
 
 .. code-block:: python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,37 +3,36 @@ Documentation
 
 .. note::
 
-  STIPS 2.0 no longer supports HST or JWST. STIPS 1.0.8 is the most recent version to 
-  offer support for those telescopes and instruments.
+  As of version 2.0, STIPS no longer offers support for HST or JWST.
 
 Overview
 --------
-STIPS is the Space Telescope Imaging Product Simulator. It is designed to create 
-simulations of full-detector post-pipeline astronomical scenes for the Nancy Grace Roman 
-Space Telescope's Wide-Field Instrument (WFI). STIPS has the ability to add 
+STIPS is the Space Telescope Imaging Product Simulator. It is designed to create
+simulations of full-detector post-pipeline astronomical scenes for the Nancy Grace Roman
+Space Telescope's Wide-Field Instrument (WFI). STIPS has the ability to add
 instrumental distortion (if available) as well as calibration residuals from flatfields,
 dark currents, and cosmic rays. It automatically includes Poisson noise and readout noise.
 It does not include instrument saturation effects.
 
 Why use STIPS?
 --------------
-STIPS is intended to produce quick simulations of Level 2 (L2) images, and is provided for 
+STIPS is intended to produce quick simulations of Level 2 (L2) images, and is provided for
 cases where `Pandeia <https://pypi.org/project/pandeia.engine/>`_ does not
 provide a large enough simulation area (e.g., full-detector or multiple-detector
 observations). STIPS obtains its Roman instrument and filter values from
 Pandeia, so it should produce output within 10% of output produced by Pandeia.
 
-STIPS does not start with Level 1 (L1) images and propagate instrumental calibrations 
+STIPS does not start with Level 1 (L1) images and propagate instrumental calibrations
 through the simulations. While it does have the ability to add error residuals (representing
-the remaining uncertainty after pipeline calibration), these residuals are not validated 
-against actual pipeline calibrations of L1 images. STIPS is not the ideal choice if 
-extremely good instrumental accuracy is needed. Pandeia is the preferred tool for 
+the remaining uncertainty after pipeline calibration), these residuals are not validated
+against actual pipeline calibrations of L1 images. STIPS is not the ideal choice if
+extremely good instrumental accuracy is needed. Pandeia is the preferred tool for
 high-accuracy observations.
 
 Developed by Brian York (`@york-stsci <https://github.com/york-stsci>`_),
-Robel Geda (`@robelgeda <https://github.com/robelgeda>`_), 
-and O. Justin Otor (`@ojustino <https://github.com/ojustino>`_). 
-Python ePSF code developed by 
+Robel Geda (`@robelgeda <https://github.com/robelgeda>`_),
+and O. Justin Otor (`@ojustino <https://github.com/ojustino>`_).
+Python ePSF code developed by
 Sebastian Gomez (`@gmzsebastian <https://github.com/gmzsebastian>`_) based on Fortran code
 developed by Andrea Bellini (`@AndreaBellini <https://github.com/AndreaBellini>`_).
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ in this section along with instructions.
 STIPS Requirements
 ##################
 
-* ``pandeia>=3.0``: Exposure time calculator.
+* ``pandeia>=3.1``: Exposure time calculator.
 
 * ``webbpsf==1.1.1``: Nancy Grace Roman PSF calculator. STIPS also requires that ``poppy``, a
   support package used by WebbPSF, have version ``>=1.0.3``.
@@ -80,9 +80,9 @@ Installing as a User
         conda activate stips
 
 
-   * Or, to install to or update an existing and currently active Conda environment::
+   * Or, to install to or update an existing Conda environment::
 
-        conda env update --file environment.yml
+        conda env update --name EXISTING-ENV --file environment.yml
 
 Installing as a Developer
 *************************
@@ -126,8 +126,8 @@ Testing Installation
 To test if all the required files have been installed, please import STIPS in Python::
 
     bash-3.2$ python
-    Python 3.7.3 | packaged by conda-forge | (default, Dec  6 2019, 08:36:57)
-    [Clang 9.0.0 (tags/RELEASE_900/final)] :: Anaconda, Inc. on darwin
+    Python 3.11.9 | packaged by conda-forge | (main, Apr 19 2024, 18:45:13)
+    [Clang 16.0.6 ] on darwin
     Type "help", "copyright", "credits" or "license" for more information.
 
     >>> import stips

--- a/docs/using_stips/psf_grid.rst
+++ b/docs/using_stips/psf_grid.rst
@@ -4,24 +4,24 @@ The STIPS PSF Grid
 Overview
 --------
 
-Starting with STIPS 2.0.0, STIPS uses WebbPSF PSF grids to implement an ePSF. The ePSF 
-uses a 3x3 grid of PSFs to handle PSF variation across the detector, and an oversample of 
+As of version 2.0.0, STIPS uses WebbPSF PSF grids to implement an ePSF. The ePSF
+uses a 3x3 grid of PSFs to handle PSF variation across the detector, and an oversample of
 4x4 to handle sub-pixel positioning. Each point source has its PSF calculated individually
 as it is added to the detector.
 
 Internal Image Size
 -------------------
 
-The size of the STIPS pre-convolution image is set by the size of the detector. In 
-addition, the image is padded by half of the PSF size on each side in order to include 
+The size of the STIPS pre-convolution image is set by the size of the detector. In
+addition, the image is padded by half of the PSF size on each side in order to include
 sources that fall off the detector, but whose PSF may land on the detector.
 
 PSF Image Size
 --------------
 
-The size of the STIPS generated PSF image depends on the source brightness. For most 
-sources, a 45x45-pixel PSF is created via an ePSF oversampled to a factor of 4. For bright 
-sources (magnitude < the bright limit, default 14), a 91x91-pixel PSF is created to 
-provide flux from the extended wings. For extra-bright sources 
-(magnitude < the extra-bright limit, default 3), a 181x181-pixel PSF is created to provide 
+The size of the STIPS generated PSF image depends on the source brightness. For most
+sources, a 45x45-pixel PSF is created via an ePSF oversampled to a factor of 4. For bright
+sources (magnitude < the bright limit, default 14), a 91x91-pixel PSF is created to
+provide flux from the extended wings. For extra-bright sources
+(magnitude < the extra-bright limit, default 3), a 181x181-pixel PSF is created to provide
 even more wing flux to the model.

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ channels:
 dependencies:
   # Base dependencies
   - pip
-  - python>=3.11
+  - python>=3.10
   - jupyter
   - Cython
   - esutil # installed from conda because you need the pre-compiled binaries.

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ channels:
 dependencies:
   # Base dependencies
   - pip
-  - python>=3.8
+  - python>=3.11
   - jupyter
   - Cython
   - esutil # installed from conda because you need the pre-compiled binaries.

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-# This file describes a conda environment that can be to install STIPS
+# This file describes a conda environment that can be used to install STIPS
 #
 # Run the following command to set up this environment:
 # $ conda env create -f environment.yml

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -28,7 +28,7 @@ channels:
 dependencies:
   # Base dependencies
   - pip
-  - python>=3.11
+  - python>=3.10
   - jupyter
   - Cython
   - esutil # installed from conda because you need the pre-compiled binaries.

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -28,7 +28,7 @@ channels:
 dependencies:
   # Base dependencies
   - pip
-  - python>=3.8
+  - python>=3.11
   - jupyter
   - Cython
   - esutil # installed from conda because you need the pre-compiled binaries.

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -1,5 +1,5 @@
-# This file describes a conda environment that can be to install STIPS for development and
-# testing purposes. Note that this environment set-up installs the STIPS module in
+# This file describes a conda environment that can be used to install STIPS for development and
+# testing purposes. Note that this environment setup installs the STIPS module in
 # editable mode, so any changes you make to the STIPS source will be reflected the next
 # time you run python.
 #

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ license = BSD 3-Clause
 url = https://github.com/spacetelescope/STScI-STIPS
 edit_on_github = False
 github_project = https://github.com/spacetelescope/STScI-STIPS
-python_requires = ">=3.11"
+python_requires = ">=3.10"
 
 [options]
 packages = stips

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = stips
 # version should be PEP440 compatible (https://www.python.org/dev/peps/pep-0440/)
-version = 2.1.0
+version = 2.2.0
 author = Space Telescope Science Institute
 author_email = york@stsci.edu
 description = STIPS is the Space Telescope Imaging Product Simulator.
@@ -10,7 +10,7 @@ license = BSD 3-Clause
 url = https://github.com/spacetelescope/STScI-STIPS
 edit_on_github = False
 github_project = https://github.com/spacetelescope/STScI-STIPS
-python_requires = ">=3.10"
+python_requires = ">=3.11"
 
 [options]
 packages = stips

--- a/stips/astro_image/astro_image.py
+++ b/stips/astro_image/astro_image.py
@@ -723,50 +723,31 @@ class AstroImage(object):
         self.shape = self.base_shape
         self.has_psf = False
 
-    def addSersicProfile(self, posX, posY, flux, n, re, phi, axialRatio, *args, **kwargs):
+    def addSersicProfile(self, posX, posY, flux, n, re, phi, axialRatio,
+                         *args, **kwargs):
         """
-        Creates a simulated Sersic profile, including PSF convolution, using pandeia's
-        SersicDistribution.
+        Create a simulated Sersic profile, including PSF convolution, using
+        Pandeia's SersicDistribution.
 
         Parameters
         ----------
-        id: int
-            The source ID of the sersic profile
-        gal_params: dict
-            A dictionary containing the galaxy parameters. These parameters are:
-            x, y: float
-                The position of the profile centre on the detector
-            flux: float
-                The surface brightness (in counts/s/pixel) at the half-light radius
-            n: float
-                The Sersic index. This must be between 0.3 and 6.2.
-            re: float
-                The half-light radius, in pixels.
-            phi: float
-                The position angle of the major axis, in degrees east of north
-            ratio: float
-                The ratio between the major and minor axes
-        psf_params: dict
-            A dictionary containing the PSF parameters. These parameters are:
-
-            psf_file: string
-                The name and location of the PSF file
-        xsize, ysize: int
-            The size of the detector
-        dir: string
-            The working directory to write model arrays to.
-        overrides: dict
-            Holds a copy of the AstroImage dictionary used to provide runtime parameter
-            setting.
-        logger: logging.logger
-            Logger to use for logging messages.
+        posX: float
+            The X position of the profile center on the detector.
+        posX: float
+            The Y position of the profile center on the detector.
+        flux: float
+            The surface brightness (in counts/s/pixel) at the half-light radius.
+        n: float
+            The Sersic index. This must be between 0.3 and 6.2.
+        re: float
+            The half-light radius, in pixels.
+        phi: float
+            The position angle of the major axis, in degrees east of north.
+        axialRatio: float
+            The ratio between the major and minor axes.
 
         Returns
         -------
-        fname: string
-            The name of the file in which the output numpy array was saved.
-        x,y: int
-            The position on the detector of the model centre
         central_flux: float
             The flux at the central pixel of the model
         """
@@ -808,52 +789,34 @@ class AstroImage(object):
         return central_flux
 
 
-    def oldSersicProfile(self, posX, posY, flux, n, re, phi, axialRatio, convolve_galaxy, *args, **kwargs):
+    def oldSersicProfile(self, posX, posY, flux, n, re, phi, axialRatio,
+                         convolve_galaxy, *args, **kwargs):
         """
-        Creates a simulated Sersic profile, including PSF convolution, using the old 
-        and faster Astropy Sersic2D model.
+        Create a simulated Sersic profile, including PSF convolution, using
+        the old (and faster) Astropy Sersic2D model.
 
         Parameters
         ----------
-        id: int
-            The source ID of the sersic profile
-        gal_params: dict
-            A dictionary containing the galaxy parameters. These parameters are:
-            x, y: float
-                The position of the profile centre on the detector
-            flux: float
-                The surface brightness (in counts/s/pixel) at the half-light radius
-            n: float
-                The Sersic index. This must be between 0.3 and 6.2.
-            re: float
-                The half-light radius, in pixels.
-            phi: float
-                The position angle of the major axis, in degrees east of north
-            ratio: float
-                The ratio between the major and minor axes
-        psf_params: dict
-            A dictionary containing the PSF parameters. These parameters are:
-
-            psf_file: string
-                The name and location of the PSF file
-        xsize, ysize: int
-            The size of the detector
-        convolve_galaxy : bool, default False
-            Convolve the final image with the Roman PSF?
-        dir: string
-            The working directory to write model arrays to.
-        overrides: dict
-            Holds a copy of the AstroImage dictionary used to provide runtime parameter
-            setting.
-        logger: logging.logger
-            Logger to use for logging messages.
+        posX: float
+            The X position of the profile center on the detector.
+        posX: float
+            The Y position of the profile center on the detector.
+        flux: float
+            The surface brightness (in counts/s/pixel) at the half-light radius.
+        n: float
+            The Sersic index. This must be between 0.3 and 6.2.
+        re: float
+            The half-light radius, in pixels.
+        phi: float
+            The position angle of the major axis, in degrees east of north.
+        axialRatio: float
+            The ratio between the major and minor axes.
+        convolve_galaxy : bool
+            Whether to convolve the final image with the Roman PSF.
+            [default: False]
 
         Returns
         -------
-        fname: string
-            The name of the file in which the output numpy array was saved.
-        x,y: int
-            The position on the detector of the model centre
         central_flux: float
             The flux at the central pixel of the model
         """


### PR DESCRIPTION
Hi @gmzsebastian, here are some edits in response to your work in spacetelescope/STScI-STIPS#175. The high-level summary:

* Updated the docstrings for `addSersicProfile()` and `oldSersicProfile()` in `stips/astro_image/astro_image.py`. The previous versions didn't actually describe the arguments used to call the methods elsewhere in the code, instead listing arguments and returned objects that don't currently appear. **Please let me know if you agree that my edits follow the functions' intended inputs and outputs.**
* Increased minimum version of Pandeia in installation docs to match the updates elsewhere.
* Increased the minimum version of Python to ~3.11~ 3.10 while also performing tests in 3.11 to match other dependencies.
* Edited `version` in `setup.cfg` to 2.2.0 – this is what actually changes the version when you install on the command line.

Also, **do you have a number for how much less accurate the `fast_galaxy` scenario is for injecting sources?** It might be useful to quantify it since you put a number on the gain in efficiency.